### PR TITLE
Fix dkms install problem with kernel version

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -4,6 +4,6 @@ PACKAGE_VERSION=4.2.2
 DEST_MODULE_LOCATION=/kernel/drivers/net/wireless
 BUILT_MODULE_NAME=8812au
 
-MAKE="'make'  all"
+MAKE="'make' all KVER=${kernelver}"
 CLEAN="'make' clean"
 AUTOINSTALL="yes"


### PR DESCRIPTION
Hi,

There is a bug, when upgrading kernel, dkms doesn't get the right kernel version (so there is a "version magic ... should be ..." bug)
Relating to https://askubuntu.com/a/832372, I solved it
