### PR TITLE
rtl8812au: Fix builds for kernels up to 6.9

### DIFF
--- a/os_dep/ioctl_cfg80211.c
+++ b/os_dep/ioctl_cfg80211.c
@@ -3658,14 +3658,23 @@ static int cfg80211_rtw_start_ap(struct wiphy *wiphy, struct net_device *ndev,
 }
 
 static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *ndev,
-                                struct cfg80211_beacon_data *info)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
+				      struct cfg80211_ap_update *info)
+#else
+				      struct cfg80211_beacon_data *info)
+#endif
 {
 	int ret = 0;
 	_adapter *adapter = wiphy_to_adapter(wiphy);
 
 	DBG_871X(FUNC_NDEV_FMT"\n", FUNC_NDEV_ARG(ndev));
-
-	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail, info->tail_len);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0))
+	ret = rtw_add_beacon(adapter, info->beacon.head, info->beacon.head_len,
+			     info->beacon.tail, info->beacon.tail_len);
+#else
+	ret = rtw_add_beacon(adapter, info->head, info->head_len, info->tail,
+			     info->tail_len);
+#endif
 
 	return ret;
 }


### PR DESCRIPTION
During commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=bb55441c57ccc5cc2eab44e1a97698b9d708871d function pointer change_beacon() parameter 'info' changed its type, so let's change our local function according to that prototype if Linux version >= 6.7.0